### PR TITLE
Support filter option for get

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ sudo dpkg -i <the_deb_name>
     # Get production log group for the last 2 hours
     saw get production --start -2h
 
+    # Get production log group for the last 2 hours and filter for "error"
+    saw get production --start -2h --filter error
+
     # Get production log group for api between 26th June 2018 and 28th June 2018
     saw get production --prefix api --start 2018-06-26 --stop 2018-06-28
     ```

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -56,4 +56,5 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 Takes an absolute timestamp in RFC3339 format, or a relative time (eg. -2h).
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 	)
+	getCommand.Flags().StringVar(&getConfig.Filter, "filter", "", "event filter pattern")
 }


### PR DESCRIPTION
This fix allows users to specify `--filter` for `get` command.