### PR TITLE
Display datetime and stream name in the output of get, and add flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ sudo dpkg -i <the_deb_name>
     - `--expand` Explode JSON objects using indenting
     - `--rawString` Print JSON strings instead of escaping ("\n", ...)
     - `--invert` Invert white colors to black for light color schemes
+    - `--raw`, or `--pretty`, for `watch` and `get` commands respectively, toggles display of the timestamp and stream name prefix.
 
 - Filter logs using CloudWatch patterns
     - `--filter foo` Filter logs for the text "foo"

--- a/blade/blade.go
+++ b/blade/blade.go
@@ -95,7 +95,11 @@ func (b *Blade) GetEvents() {
 
 	handlePage := func(page *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
 		for _, event := range page.Events {
-			fmt.Print(formatEvent(formatter, event))
+			if b.output.Pretty {
+				fmt.Println(formatEvent(formatter, event))
+			} else {
+				fmt.Println(*event.Message)
+			}
 		}
 		return !lastPage
 	}
@@ -132,7 +136,11 @@ func (b *Blade) StreamEvents() {
 		for _, event := range page.Events {
 			updateLastSeenTime(event.Timestamp)
 			if _, seen := seenEventIDs[*event.EventId]; !seen {
-				fmt.Print(formatEvent(formatter, event))
+				if b.output.Raw {
+					fmt.Println(*event.Message)
+				} else {
+					fmt.Println(formatEvent(formatter, event))
+				}
 				addSeenEventIDs(event.EventId)
 			}
 		}
@@ -165,9 +173,9 @@ func formatEvent(formatter *colorjson.Formatter, event *cloudwatchlogs.FilteredL
 	jl := map[string]interface{}{}
 
 	if err := json.Unmarshal(bytes, &jl); err != nil {
-		return fmt.Sprintf("[%s] (%s) %s\n", red(dateStr), white(streamStr), str)
+		return fmt.Sprintf("[%s] (%s) %s", red(dateStr), white(streamStr), str)
 	}
 
 	output, _ := formatter.Marshal(jl)
-	return fmt.Sprintf("[%s] (%s) %s\n", red(dateStr), white(streamStr), output)
+	return fmt.Sprintf("[%s] (%s) %s", red(dateStr), white(streamStr), output)
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -11,6 +11,7 @@ import (
 )
 
 var getConfig config.Configuration
+var getOutputConfig config.OutputConfiguration
 
 var getCommand = &cobra.Command{
 	Use:   "get <log group>",
@@ -24,7 +25,7 @@ var getCommand = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		getConfig.Group = args[0]
-		b := blade.NewBlade(&getConfig, &awsConfig, nil)
+		b := blade.NewBlade(&getConfig, &awsConfig, &getOutputConfig)
 		if getConfig.Prefix != "" {
 			streams := b.GetLogStreams()
 			if len(streams) == 0 {
@@ -57,4 +58,7 @@ Takes an absolute timestamp in RFC3339 format, or a relative time (eg. -2h).
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 	)
 	getCommand.Flags().StringVar(&getConfig.Filter, "filter", "", "event filter pattern")
+	getCommand.Flags().BoolVar(&getOutputConfig.Expand, "expand", false, "indent JSON log messages")
+	getCommand.Flags().BoolVar(&getOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")
+	getCommand.Flags().BoolVar(&getOutputConfig.RawString, "rawString", false, "print JSON strings without escaping")
 }

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -58,6 +58,7 @@ Takes an absolute timestamp in RFC3339 format, or a relative time (eg. -2h).
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 	)
 	getCommand.Flags().StringVar(&getConfig.Filter, "filter", "", "event filter pattern")
+	getCommand.Flags().BoolVar(&getOutputConfig.Pretty, "pretty", false, "print timestamp and stream name prefix")
 	getCommand.Flags().BoolVar(&getOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	getCommand.Flags().BoolVar(&getOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")
 	getCommand.Flags().BoolVar(&getOutputConfig.RawString, "rawString", false, "print JSON strings without escaping")

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -11,6 +11,7 @@ import (
 )
 
 var watchConfig config.Configuration
+
 var watchOutputConfig config.OutputConfiguration
 
 var watchCommand = &cobra.Command{
@@ -42,6 +43,7 @@ var watchCommand = &cobra.Command{
 func init() {
 	watchCommand.Flags().StringVar(&watchConfig.Prefix, "prefix", "", "log stream prefix filter")
 	watchCommand.Flags().StringVar(&watchConfig.Filter, "filter", "", "event filter pattern")
+	watchCommand.Flags().BoolVar(&watchOutputConfig.Raw, "raw", false, "print raw log event without timestamp or stream prefix")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.RawString, "rawString", false, "print JSON strings without escaping")

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -11,7 +11,7 @@ import (
 )
 
 var watchConfig config.Configuration
-var outputConfig config.OutputConfiguration
+var watchOutputConfig config.OutputConfiguration
 
 var watchCommand = &cobra.Command{
 	Use:   "watch <log group>",
@@ -25,7 +25,7 @@ var watchCommand = &cobra.Command{
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		watchConfig.Group = args[0]
-		b := blade.NewBlade(&watchConfig, &awsConfig, &outputConfig)
+		b := blade.NewBlade(&watchConfig, &awsConfig, &watchOutputConfig)
 		if watchConfig.Prefix != "" {
 			streams := b.GetLogStreams()
 			if len(streams) == 0 {
@@ -42,7 +42,7 @@ var watchCommand = &cobra.Command{
 func init() {
 	watchCommand.Flags().StringVar(&watchConfig.Prefix, "prefix", "", "log stream prefix filter")
 	watchCommand.Flags().StringVar(&watchConfig.Filter, "filter", "", "event filter pattern")
-	watchCommand.Flags().BoolVar(&outputConfig.Expand, "expand", false, "indent JSON log messages")
-	watchCommand.Flags().BoolVar(&outputConfig.Invert, "invert", false, "invert colors for light terminal themes")
-	watchCommand.Flags().BoolVar(&outputConfig.RawString, "rawString", false, "print JSON strings without escaping")
+	watchCommand.Flags().BoolVar(&watchOutputConfig.Expand, "expand", false, "indent JSON log messages")
+	watchCommand.Flags().BoolVar(&watchOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")
+	watchCommand.Flags().BoolVar(&watchOutputConfig.RawString, "rawString", false, "print JSON strings without escaping")
 }

--- a/config/output.go
+++ b/config/output.go
@@ -6,13 +6,12 @@ import (
 )
 
 type OutputConfiguration struct {
-	Expand         bool
-	Raw            bool
-	RawString      bool
-	HideStreamName bool
-	HideDate       bool
-	Invert         bool
-	NoColor        bool
+	Raw       bool
+	Pretty    bool
+	Expand    bool
+	Invert    bool
+	RawString bool
+	NoColor   bool
 }
 
 func (c *OutputConfiguration) Formatter() *colorjson.Formatter {


### PR DESCRIPTION
Changes the way the formatting occurs for the log events, so that the format can be shared between the different commands. Also adds the flags available on the watch command to the get command for feature parity.

Closes #13 