### PR TITLE
Deduplicate newlines in message endings for compact output

### DIFF
--- a/blade/blade.go
+++ b/blade/blade.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/TylerBrock/colorjson"
@@ -136,11 +137,14 @@ func (b *Blade) StreamEvents() {
 		for _, event := range page.Events {
 			updateLastSeenTime(event.Timestamp)
 			if _, seen := seenEventIDs[*event.EventId]; !seen {
+				var message string
 				if b.output.Raw {
-					fmt.Println(*event.Message)
+					message = *event.Message
 				} else {
-					fmt.Println(formatEvent(formatter, event))
+					message = formatEvent(formatter, event)
 				}
+				message = strings.TrimRight(message, "\n")
+				fmt.Println(message)
 				addSeenEventIDs(event.EventId)
 			}
 		}


### PR DESCRIPTION
Hey. First of all, thanks, this tool is awesome.

Just a small suggestion: if an event message has "\n ending, `Println` will basically print two newlines, this will expand output too much. My PR ensures there's only one "\n" in the end.

Before:

```
[2018-10-14T23:37:24+03:00] ... Message 1

[2018-10-14T23:37:24+03:00] ...	Message 2

[2018-10-14T23:37:24+03:00] ... Message 3
```

After:

```
[2018-10-14T23:37:24+03:00] ... Message 1
[2018-10-14T23:37:24+03:00] ...	Message 2
[2018-10-14T23:37:24+03:00] ... Message 3
```