### PR TITLE
Added error handling of AWS SDK errors when using groups command

### DIFF
--- a/blade/blade.go
+++ b/blade/blade.go
@@ -3,6 +3,7 @@ package blade
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"os"
 	"strings"
 	"time"
@@ -57,10 +58,10 @@ func NewBlade(
 }
 
 // GetLogGroups gets the log groups from AWS given the blade configuration
-func (b *Blade) GetLogGroups() []*cloudwatchlogs.LogGroup {
+func (b *Blade) GetLogGroups() ([]*cloudwatchlogs.LogGroup, awserr.Error) {
 	input := b.config.DescribeLogGroupsInput()
 	groups := make([]*cloudwatchlogs.LogGroup, 0)
-	b.cwl.DescribeLogGroupsPages(input, func(
+	err := b.cwl.DescribeLogGroupsPages(input, func(
 		out *cloudwatchlogs.DescribeLogGroupsOutput,
 		lastPage bool,
 	) bool {
@@ -69,7 +70,10 @@ func (b *Blade) GetLogGroups() []*cloudwatchlogs.LogGroup {
 		}
 		return !lastPage
 	})
-	return groups
+	if awsErr, ok := err.(awserr.Error); ok {
+		return groups, awsErr
+	}
+	return groups, nil
 }
 
 // GetLogStreams gets the log streams from AWS given the blade configuration

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
-
 	"github.com/TylerBrock/saw/blade"
 	"github.com/TylerBrock/saw/config"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 // TODO: colorize based on logGroup prefix (/aws/lambda, /aws/kinesisfirehose, etc...)
@@ -17,7 +17,13 @@ var groupsCommand = &cobra.Command{
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
 		b := blade.NewBlade(&groupsConfig, &awsConfig, nil)
-		logGroups := b.GetLogGroups()
+		logGroups, err := b.GetLogGroups()
+
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Code()+": "+err.Message())
+			os.Exit(1)
+		}
+
 		for _, group := range logGroups {
 			fmt.Println(*group.LogGroupName)
 		}


### PR DESCRIPTION
It can be a little confusing when diagnosing profile configuration issues when first using the tool given the groups command is likely the first one you'd attempt to use. I've added some simple error handling for this command to ensure feedback is provided to make it easier for anyone using the tool to diagnose any issue. 