### PR TITLE
Support more time formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ export AWS_PROFILE='work_profile'
 export AWS_REGION='us-west-1'
 ```
 
+## Run Tests
+From root of repository: `go test -v ./...`
+
 ## TODO
 
 - Bash + ZSH completion of log groups + (streams?)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -23,6 +23,9 @@ type Configuration struct {
 // Define the order of time formats to attempt to use to parse our input absolute time
 var absoluteTimeFormats = []string{
 	time.RFC3339,
+
+  "2006-01-02", // Simple date
+  "2006-01-02 15:04:05", // Simple date & time
 }
 
 // Parse the input string into a time.Time object.

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -24,8 +24,8 @@ type Configuration struct {
 var absoluteTimeFormats = []string{
 	time.RFC3339,
 
-  "2006-01-02", // Simple date
-  "2006-01-02 15:04:05", // Simple date & time
+	"2006-01-02",          // Simple date
+	"2006-01-02 15:04:05", // Simple date & time
 }
 
 // Parse the input string into a time.Time object.
@@ -36,7 +36,7 @@ func getTime(timeStr string, currentTime time.Time) (time.Time, error) {
 		return currentTime.Add(relative), nil
 	}
 
-  // Iterate over available absolute time formats until we find one that works
+	// Iterate over available absolute time formats until we find one that works
 	for _, timeFormat := range absoluteTimeFormats {
 		absolute, err := time.Parse(timeFormat, timeStr)
 

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -29,3 +29,19 @@ func TestGetTimeAbsoluteRFC3339(t *testing.T) {
     t.Errorf("Expected to parse absolute time. Error: %s", err)
   }
 }
+
+func TestGetTimeAbsoluteSimpleDate(t *testing.T) {
+  absoluteTime1, err := getTime("2018-06-26", testTimeNow)
+
+  if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 0 && absoluteTime1.Minute() == 0 && absoluteTime1.Second() == 0  {
+    t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
+  }
+}
+
+func TestGetTimeAbsoluteSimpleDateAndTime(t *testing.T) {
+  absoluteTime1, err := getTime("2018-06-26 12:43:30", testTimeNow)
+
+  if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 12 && absoluteTime1.Minute() == 43 && absoluteTime1.Second() == 30  {
+    t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
+  }
+}

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -1,0 +1,31 @@
+package config
+
+import (
+  "testing"
+  "time"
+)
+
+var testTimeNow = time.Date(2018, 12, 01, 15, 30, 0, 0, time.UTC)
+
+// test the relative parsing functionality of getTime
+func TestGetTimeRelative(t *testing.T) {
+  relativeTest1, err := getTime("-2h", testTimeNow)
+
+  if err != nil || relativeTest1.Hour() != 13 {
+    t.Errorf("Expected relativeTest1 to set time back by two hours. Error: %s", err)
+  }
+
+  relativeTest2, err := getTime("-1h15m", testTimeNow)
+  if err != nil || !(relativeTest2.Hour() == 14 && relativeTest2.Minute() == 15) {
+    t.Errorf("Expected relativeTest2 to set time back by 1 hour and 15 minutes. Error: %s", err)
+  }
+}
+
+// test the absolute RFC3339 parsing functionality of getTime
+func TestGetTimeAbsoluteRFC3339(t *testing.T) {
+  absoluteTime1, err := getTime("2006-01-02T15:04:05+07:00", testTimeNow)
+
+  if err != nil && absoluteTime1.Hour() == 15 && absoluteTime1.Minute() == 4 {
+    t.Errorf("Expected to parse absolute time. Error: %s", err)
+  }
+}

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -1,47 +1,47 @@
 package config
 
 import (
-  "testing"
-  "time"
+	"testing"
+	"time"
 )
 
 var testTimeNow = time.Date(2018, 12, 01, 15, 30, 0, 0, time.UTC)
 
 // test the relative parsing functionality of getTime
 func TestGetTimeRelative(t *testing.T) {
-  relativeTest1, err := getTime("-2h", testTimeNow)
+	relativeTest1, err := getTime("-2h", testTimeNow)
 
-  if err != nil || relativeTest1.Hour() != 13 {
-    t.Errorf("Expected relativeTest1 to set time back by two hours. Error: %s", err)
-  }
+	if err != nil || relativeTest1.Hour() != 13 {
+		t.Errorf("Expected relativeTest1 to set time back by two hours. Error: %s", err)
+	}
 
-  relativeTest2, err := getTime("-1h15m", testTimeNow)
-  if err != nil || !(relativeTest2.Hour() == 14 && relativeTest2.Minute() == 15) {
-    t.Errorf("Expected relativeTest2 to set time back by 1 hour and 15 minutes. Error: %s", err)
-  }
+	relativeTest2, err := getTime("-1h15m", testTimeNow)
+	if err != nil || !(relativeTest2.Hour() == 14 && relativeTest2.Minute() == 15) {
+		t.Errorf("Expected relativeTest2 to set time back by 1 hour and 15 minutes. Error: %s", err)
+	}
 }
 
 // test the absolute RFC3339 parsing functionality of getTime
 func TestGetTimeAbsoluteRFC3339(t *testing.T) {
-  absoluteTime1, err := getTime("2006-01-02T15:04:05+07:00", testTimeNow)
+	absoluteTime1, err := getTime("2006-01-02T15:04:05+07:00", testTimeNow)
 
-  if err != nil && absoluteTime1.Hour() == 15 && absoluteTime1.Minute() == 4 {
-    t.Errorf("Expected to parse absolute time. Error: %s", err)
-  }
+	if err != nil && absoluteTime1.Hour() == 15 && absoluteTime1.Minute() == 4 {
+		t.Errorf("Expected to parse absolute time. Error: %s", err)
+	}
 }
 
 func TestGetTimeAbsoluteSimpleDate(t *testing.T) {
-  absoluteTime1, err := getTime("2018-06-26", testTimeNow)
+	absoluteTime1, err := getTime("2018-06-26", testTimeNow)
 
-  if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 0 && absoluteTime1.Minute() == 0 && absoluteTime1.Second() == 0  {
-    t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
-  }
+	if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 0 && absoluteTime1.Minute() == 0 && absoluteTime1.Second() == 0 {
+		t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
+	}
 }
 
 func TestGetTimeAbsoluteSimpleDateAndTime(t *testing.T) {
-  absoluteTime1, err := getTime("2018-06-26 12:43:30", testTimeNow)
+	absoluteTime1, err := getTime("2018-06-26 12:43:30", testTimeNow)
 
-  if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 12 && absoluteTime1.Minute() == 43 && absoluteTime1.Second() == 30  {
-    t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
-  }
+	if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 12 && absoluteTime1.Minute() == 43 && absoluteTime1.Second() == 30 {
+		t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
+	}
 }

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -7,53 +7,48 @@ import (
 
 var testTimeNow = time.Date(2018, 12, 01, 15, 30, 0, 0, time.UTC)
 
+/*
+ * Helper method to assert equality of time objects in our tests
+ */
+func assertTimeEquality(t *testing.T, expected *time.Time, result *time.Time, err error) bool {
+  if err != nil || !result.Equal(*expected) {
+    t.Errorf("Expected to parse absolute time from simple string. Error: %s. Expected Time: %s, Absolute Time: %s", err, expected.String(), result.String())
+
+    return false;
+  }
+
+  return true;
+}
+
 // test the relative parsing functionality of getTime
 func TestGetTimeRelative(t *testing.T) {
-	relativeTest1, err := getTime("-2h", testTimeNow)
+  expectedTime1 := time.Date(2018, 12, 01, 13, 30, 0, 0, time.UTC)
+	relativeTime1, err := getTime("-2h", testTimeNow)
+  assertTimeEquality(t, &expectedTime1, &relativeTime1, err)
 
-	if err != nil || relativeTest1.Hour() != 13 {
-		t.Errorf("Expected relativeTest1 to set time back by two hours. Error: %s", err)
-	}
-
-	relativeTest2, err := getTime("-1h15m", testTimeNow)
-	if err != nil || !(relativeTest2.Hour() == 14 && relativeTest2.Minute() == 15) {
-		t.Errorf("Expected relativeTest2 to set time back by 1 hour and 15 minutes. Error: %s", err)
-	}
+  expectedTime2 := time.Date(2018, 12, 01, 14, 15, 0, 0, time.UTC)
+	relativeTime2, err := getTime("-1h15m", testTimeNow)
+  assertTimeEquality(t, &expectedTime2, &relativeTime2, err)
 }
 
 // test the absolute RFC3339 parsing functionality of getTime
 func TestGetTimeAbsoluteRFC3339(t *testing.T) {
-	absoluteTime1, err := getTime("2006-01-02T15:04:05+07:00", testTimeNow)
+  expectedTime := time.Date(2006, 1, 2, 23, 4, 5, 0, time.UTC)
+	absoluteTime1, err := getTime("2006-01-02T15:04:05-08:00", testTimeNow)
 
-	if err != nil && absoluteTime1.Hour() == 15 && absoluteTime1.Minute() == 4 {
-		t.Errorf("Expected to parse absolute time. Error: %s", err)
-	}
+  assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
 }
 
 func TestGetTimeAbsoluteSimpleDate(t *testing.T) {
+  expectedTime := time.Date(2018, 6, 26, 0, 0, 0, 0, time.UTC)
 	absoluteTime1, err := getTime("2018-06-26", testTimeNow)
 
-	if err != nil &&
-		absoluteTime1.Year() == 2018 &&
-		absoluteTime1.Month() == 6 &&
-		absoluteTime1.Day() == 26 &&
-		absoluteTime1.Hour() == 0 &&
-		absoluteTime1.Minute() == 0 &&
-		absoluteTime1.Second() == 0 {
-		t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
-	}
+  assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
 }
 
 func TestGetTimeAbsoluteSimpleDateAndTime(t *testing.T) {
+  expectedTime := time.Date(2018, 6, 26, 12, 43, 30, 0, time.UTC)
 	absoluteTime1, err := getTime("2018-06-26 12:43:30", testTimeNow)
 
-	if err != nil &&
-		absoluteTime1.Year() == 2018 &&
-		absoluteTime1.Month() == 6 &&
-		absoluteTime1.Day() == 26 &&
-		absoluteTime1.Hour() == 12 &&
-		absoluteTime1.Minute() == 43 &&
-		absoluteTime1.Second() == 30 {
-		t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
-	}
+  assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
 }

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -11,44 +11,44 @@ var testTimeNow = time.Date(2018, 12, 01, 15, 30, 0, 0, time.UTC)
  * Helper method to assert equality of time objects in our tests
  */
 func assertTimeEquality(t *testing.T, expected *time.Time, result *time.Time, err error) bool {
-  if err != nil || !result.Equal(*expected) {
-    t.Errorf("Expected to parse absolute time from simple string. Error: %s. Expected Time: %s, Absolute Time: %s", err, expected.String(), result.String())
+	if err != nil || !result.Equal(*expected) {
+		t.Errorf("Expected to parse absolute time from simple string. Error: %s. Expected Time: %s, Absolute Time: %s", err, expected.String(), result.String())
 
-    return false;
-  }
+		return false
+	}
 
-  return true;
+	return true
 }
 
 // test the relative parsing functionality of getTime
 func TestGetTimeRelative(t *testing.T) {
-  expectedTime1 := time.Date(2018, 12, 01, 13, 30, 0, 0, time.UTC)
+	expectedTime1 := time.Date(2018, 12, 01, 13, 30, 0, 0, time.UTC)
 	relativeTime1, err := getTime("-2h", testTimeNow)
-  assertTimeEquality(t, &expectedTime1, &relativeTime1, err)
+	assertTimeEquality(t, &expectedTime1, &relativeTime1, err)
 
-  expectedTime2 := time.Date(2018, 12, 01, 14, 15, 0, 0, time.UTC)
+	expectedTime2 := time.Date(2018, 12, 01, 14, 15, 0, 0, time.UTC)
 	relativeTime2, err := getTime("-1h15m", testTimeNow)
-  assertTimeEquality(t, &expectedTime2, &relativeTime2, err)
+	assertTimeEquality(t, &expectedTime2, &relativeTime2, err)
 }
 
 // test the absolute RFC3339 parsing functionality of getTime
 func TestGetTimeAbsoluteRFC3339(t *testing.T) {
-  expectedTime := time.Date(2006, 1, 2, 23, 4, 5, 0, time.UTC)
+	expectedTime := time.Date(2006, 1, 2, 23, 4, 5, 0, time.UTC)
 	absoluteTime1, err := getTime("2006-01-02T15:04:05-08:00", testTimeNow)
 
-  assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
+	assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
 }
 
 func TestGetTimeAbsoluteSimpleDate(t *testing.T) {
-  expectedTime := time.Date(2018, 6, 26, 0, 0, 0, 0, time.UTC)
+	expectedTime := time.Date(2018, 6, 26, 0, 0, 0, 0, time.UTC)
 	absoluteTime1, err := getTime("2018-06-26", testTimeNow)
 
-  assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
+	assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
 }
 
 func TestGetTimeAbsoluteSimpleDateAndTime(t *testing.T) {
-  expectedTime := time.Date(2018, 6, 26, 12, 43, 30, 0, time.UTC)
+	expectedTime := time.Date(2018, 6, 26, 12, 43, 30, 0, time.UTC)
 	absoluteTime1, err := getTime("2018-06-26 12:43:30", testTimeNow)
 
-  assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
+	assertTimeEquality(t, &expectedTime, &absoluteTime1, err)
 }

--- a/config/configuration_test.go
+++ b/config/configuration_test.go
@@ -33,7 +33,13 @@ func TestGetTimeAbsoluteRFC3339(t *testing.T) {
 func TestGetTimeAbsoluteSimpleDate(t *testing.T) {
 	absoluteTime1, err := getTime("2018-06-26", testTimeNow)
 
-	if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 0 && absoluteTime1.Minute() == 0 && absoluteTime1.Second() == 0 {
+	if err != nil &&
+		absoluteTime1.Year() == 2018 &&
+		absoluteTime1.Month() == 6 &&
+		absoluteTime1.Day() == 26 &&
+		absoluteTime1.Hour() == 0 &&
+		absoluteTime1.Minute() == 0 &&
+		absoluteTime1.Second() == 0 {
 		t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
 	}
 }
@@ -41,7 +47,13 @@ func TestGetTimeAbsoluteSimpleDate(t *testing.T) {
 func TestGetTimeAbsoluteSimpleDateAndTime(t *testing.T) {
 	absoluteTime1, err := getTime("2018-06-26 12:43:30", testTimeNow)
 
-	if err != nil && absoluteTime1.Year() == 2018 && absoluteTime1.Month() == 6 && absoluteTime1.Day() == 26 && absoluteTime1.Hour() == 12 && absoluteTime1.Minute() == 43 && absoluteTime1.Second() == 30 {
+	if err != nil &&
+		absoluteTime1.Year() == 2018 &&
+		absoluteTime1.Month() == 6 &&
+		absoluteTime1.Day() == 26 &&
+		absoluteTime1.Hour() == 12 &&
+		absoluteTime1.Minute() == 43 &&
+		absoluteTime1.Second() == 30 {
 		t.Errorf("Expected to parse absolute time from simple string. Error: %s", err)
 	}
 }


### PR DESCRIPTION
Useful tool, first of all. Thanks for writing it.

Currently the time parsing for the `--start` and `--end` parameters is limited to the restrictive and annoying `time.RFC3339`. This change allows the program to try multiple time formats until one matches.

I've also added some basic tests for the `getTime` method.

Fixes https://github.com/TylerBrock/saw/issues/16 and https://github.com/TylerBrock/saw/issues/26