### PR TITLE
Make it more palatable for docker-compose environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ sudo dpkg -i <the_deb_name>
     # Watch production log group streams for api
     saw watch production --prefix api
 
+    # Watch recently changed streams for the production log group
+    saw watch production --recent
+
     # Watch production log group streams for api and filter for "error"
     saw watch production --prefix api --filter error
     ```

--- a/blade/blade.go
+++ b/blade/blade.go
@@ -89,6 +89,25 @@ func (b *Blade) GetLogStreams() []*cloudwatchlogs.LogStream {
 	return streams
 }
 
+// GetTopLogStreams gets the recent log streams from AWS without prefix and limited to 100
+func (b *Blade) GetTopLogStreams() []*cloudwatchlogs.LogStream {
+	input := b.config.DescribeRecentLogStreamsInput()
+	streams := make([]*cloudwatchlogs.LogStream, 0)
+	b.cwl.DescribeLogStreamsPages(input, func(
+		out *cloudwatchlogs.DescribeLogStreamsOutput,
+		lastPage bool,
+	) bool {
+		for _, stream := range out.LogStreams {
+			streams = append(streams, stream)
+		}
+		if lastPage || len(streams) >= 100 {
+			return false
+		}
+		return true
+	})
+	return streams
+}
+
 // GetEvents gets events from AWS given the blade configuration
 func (b *Blade) GetEvents() {
 	formatter := b.output.Formatter()
@@ -150,6 +169,7 @@ func (b *Blade) StreamEvents() {
 		}
 		return !lastPage
 	}
+	fmt.Printf("starting to tail logs from %d streams ...\n", len(input.LogStreamNames))
 
 	for {
 		err := b.cwl.FilterLogEventsPages(input, handlePage)

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -72,6 +72,14 @@ func (c *Configuration) DescribeLogStreamsInput() *cloudwatchlogs.DescribeLogStr
 	return &input
 }
 
+func (c *Configuration) DescribeRecentLogStreamsInput() *cloudwatchlogs.DescribeLogStreamsInput {
+	input := cloudwatchlogs.DescribeLogStreamsInput{}
+	input.SetLogGroupName(c.Group)
+	input.SetDescending(true)
+	input.SetOrderBy("LastEventTime")
+	return &input
+}
+
 func (c *Configuration) FilterLogEventsInput() *cloudwatchlogs.FilterLogEventsInput {
 	input := cloudwatchlogs.FilterLogEventsInput{}
 	input.SetInterleaved(true)


### PR DESCRIPTION
ECS creates log stream per container and the current watch method takes about 2 minutes in my environment to get log streams. Since ECS creates log group per task, I added a `--recent` flag to find streams based on `EventTime`. 