### PR TITLE
Flag to print specific JSON key

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -58,6 +58,7 @@ Takes an absolute timestamp in RFC3339 format, or a relative time (eg. -2h).
 Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 	)
 	getCommand.Flags().StringVar(&getConfig.Filter, "filter", "", "event filter pattern")
+	getCommand.Flags().StringVar(&watchConfig.Key, "key", "", "print this key for JSON-formatted messages")
 	getCommand.Flags().BoolVar(&getOutputConfig.Pretty, "pretty", false, "print timestamp and stream name prefix")
 	getCommand.Flags().BoolVar(&getOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	getCommand.Flags().BoolVar(&getOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -43,6 +43,7 @@ var watchCommand = &cobra.Command{
 func init() {
 	watchCommand.Flags().StringVar(&watchConfig.Prefix, "prefix", "", "log stream prefix filter")
 	watchCommand.Flags().StringVar(&watchConfig.Filter, "filter", "", "event filter pattern")
+	watchCommand.Flags().StringVar(&watchConfig.Key, "key", "", "print this key for JSON-formatted messages")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Raw, "raw", false, "print raw log event without timestamp or stream prefix")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")

--- a/config/configuration.go
+++ b/config/configuration.go
@@ -15,6 +15,7 @@ type Configuration struct {
 	Start      string
 	End        string
 	Filter     string
+	Key        string
 	Streams    []*cloudwatchlogs.LogStream
 	Descending bool
 	OrderBy    string


### PR DESCRIPTION
This adds a `--key` argument which allows printing only a partial JSON object. My use case is writing logs in JSON, but when using saw I tend to filter down to just what I want and so would rather just see `${event.message}` rather than the whole JSON object

```
saw watch /logs/nomad --prefix my_app --filter "200 OK" --key message
```
I don't really "know" Go, so this PR is probably pretty terrible. There's certainly no error handling. Let me know if you'd accept this functionality and I'm happy to clean it up.