### PR TITLE
support multi-group log commands

### DIFF
--- a/blade/blade.go
+++ b/blade/blade.go
@@ -97,7 +97,7 @@ func (b *Blade) GetEvents() {
 	handlePage := func(page *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
 		for _, event := range page.Events {
 			if b.output.Pretty {
-				fmt.Println(formatEvent(formatter, event))
+				fmt.Println(formatEvent(formatter, event, b.config.Group))
 			} else {
 				fmt.Println(*event.Message)
 			}
@@ -141,7 +141,7 @@ func (b *Blade) StreamEvents() {
 				if b.output.Raw {
 					message = *event.Message
 				} else {
-					message = formatEvent(formatter, event)
+					message = formatEvent(formatter, event, b.config.Group)
 				}
 				message = strings.TrimRight(message, "\n")
 				fmt.Println(message)
@@ -165,8 +165,9 @@ func (b *Blade) StreamEvents() {
 }
 
 // formatEvent returns a CloudWatch log event as a formatted string using the provided formatter
-func formatEvent(formatter *colorjson.Formatter, event *cloudwatchlogs.FilteredLogEvent) string {
+func formatEvent(formatter *colorjson.Formatter, event *cloudwatchlogs.FilteredLogEvent, group string) string {
 	red := color.New(color.FgRed).SprintFunc()
+	yellow := color.New(color.FgYellow).SprintFunc()
 	white := color.New(color.FgWhite).SprintFunc()
 
 	str := aws.StringValue(event.Message)
@@ -177,9 +178,9 @@ func formatEvent(formatter *colorjson.Formatter, event *cloudwatchlogs.FilteredL
 	jl := map[string]interface{}{}
 
 	if err := json.Unmarshal(bytes, &jl); err != nil {
-		return fmt.Sprintf("[%s] (%s) %s", red(dateStr), white(streamStr), str)
+		return fmt.Sprintf("[%s] (%s:%s) %s", red(dateStr), yellow(group), white(streamStr), str)
 	}
 
 	output, _ := formatter.Marshal(jl)
-	return fmt.Sprintf("[%s] (%s) %s", red(dateStr), white(streamStr), output)
+	return fmt.Sprintf("[%s] (%s:%s) %s", red(dateStr), yellow(group), white(streamStr), output)
 }

--- a/cmd/saw.go
+++ b/cmd/saw.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+	"regexp"
+	"sync"
+
+	"github.com/TylerBrock/saw/blade"
 	"github.com/TylerBrock/saw/config"
 	"github.com/spf13/cobra"
 )
@@ -28,4 +33,30 @@ func init() {
 	SawCommand.AddCommand(getCommand)
 	SawCommand.PersistentFlags().StringVar(&awsConfig.Region, "region", "", "override profile AWS region")
 	SawCommand.PersistentFlags().StringVar(&awsConfig.Profile, "profile", "", "override default AWS profile")
+}
+
+func runMultiGroup(pattern string, fn func(string)) error {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return fmt.Errorf("invalid <log group> pattern: %s", err)
+	}
+
+	b := blade.NewBlade(&config.Configuration{}, &awsConfig, nil)
+
+	var wg sync.WaitGroup
+	for _, group := range b.GetLogGroups() {
+		name := group.LogGroupName
+		if name == nil || !re.MatchString(*name) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(group string) {
+			defer wg.Done()
+			fn(group)
+		}(*name)
+	}
+
+	wg.Wait()
+	return nil
 }

--- a/cmd/streams.go
+++ b/cmd/streams.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/TylerBrock/saw/blade"
 	"github.com/TylerBrock/saw/config"
 	"github.com/spf13/cobra"
 )
 
-var streamsConfig config.Configuration
+var streamsConfigGlobal config.Configuration
 
 var streamsCommand = &cobra.Command{
 	Use:   "streams <log group>",
@@ -22,18 +23,26 @@ var streamsCommand = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		streamsConfig.Group = args[0]
-		b := blade.NewBlade(&streamsConfig, &awsConfig, nil)
+		err := runMultiGroup(args[0], func(group string) {
+			streamsConfig := streamsConfigGlobal
+			streamsConfig.Group = args[0]
+			b := blade.NewBlade(&streamsConfig, &awsConfig, nil)
 
-		logStreams := b.GetLogStreams()
-		for _, stream := range logStreams {
-			fmt.Println(*stream.LogStreamName)
+			logStreams := b.GetLogStreams()
+			for _, stream := range logStreams {
+				fmt.Println(*stream.LogStreamName)
+			}
+		})
+
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
 		}
 	},
 }
 
 func init() {
-	streamsCommand.Flags().StringVar(&streamsConfig.Prefix, "prefix", "", "stream prefix filter")
-	streamsCommand.Flags().StringVar(&streamsConfig.OrderBy, "orderBy", "LogStreamName", "order streams by LogStreamName or LastEventTime")
-	streamsCommand.Flags().BoolVar(&streamsConfig.Descending, "descending", false, "order streams descending")
+	streamsCommand.Flags().StringVar(&streamsConfigGlobal.Prefix, "prefix", "", "stream prefix filter")
+	streamsCommand.Flags().StringVar(&streamsConfigGlobal.OrderBy, "orderBy", "LogStreamName", "order streams by LogStreamName or LastEventTime")
+	streamsCommand.Flags().BoolVar(&streamsConfigGlobal.Descending, "descending", false, "order streams descending")
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var watchConfig config.Configuration
+var watchConfigGlobal config.Configuration
 
 var watchOutputConfig config.OutputConfiguration
 
@@ -25,24 +25,32 @@ var watchCommand = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		watchConfig.Group = args[0]
-		b := blade.NewBlade(&watchConfig, &awsConfig, &watchOutputConfig)
-		if watchConfig.Prefix != "" {
-			streams := b.GetLogStreams()
-			if len(streams) == 0 {
-				fmt.Printf("No streams found in %s with prefix %s\n", watchConfig.Group, watchConfig.Prefix)
-				fmt.Printf("To view available streams: `saw streams %s`\n", watchConfig.Group)
-				os.Exit(3)
+		err := runMultiGroup(args[0], func(group string) {
+			watchConfig := watchConfigGlobal
+			watchConfig.Group = group
+			b := blade.NewBlade(&watchConfig, &awsConfig, &watchOutputConfig)
+			if watchConfig.Prefix != "" {
+				streams := b.GetLogStreams()
+				if len(streams) == 0 {
+					fmt.Printf("No streams found in %s with prefix %s\n", watchConfig.Group, watchConfig.Prefix)
+					fmt.Printf("To view available streams: `saw streams %s`\n", watchConfig.Group)
+					os.Exit(3)
+				}
+				watchConfig.Streams = streams
 			}
-			watchConfig.Streams = streams
+			b.StreamEvents()
+		})
+
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
 		}
-		b.StreamEvents()
 	},
 }
 
 func init() {
-	watchCommand.Flags().StringVar(&watchConfig.Prefix, "prefix", "", "log stream prefix filter")
-	watchCommand.Flags().StringVar(&watchConfig.Filter, "filter", "", "event filter pattern")
+	watchCommand.Flags().StringVar(&watchConfigGlobal.Prefix, "prefix", "", "log stream prefix filter")
+	watchCommand.Flags().StringVar(&watchConfigGlobal.Filter, "filter", "", "event filter pattern")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Raw, "raw", false, "print raw log event without timestamp or stream prefix")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")


### PR DESCRIPTION
With this change, the first argument to the command is parsed as a
regular expression and matched against the list of available log groups.
For each matched log group, the relevant command is executed in
parallel.

The following commands support this pattern:

* `get`
* `streams`
* `watch`

The log group name is added to the formatted log output, to distinguish
logs from different log groups.

If you want to get an idential result as what you got before this
commit, you would have to wrap your group name in regular expression
begin and end tokens, meaning this:

    saw stream "my-log-group"

Must now be written as:

    saw stream "^my-log-group$"

Closes #38