### PR TITLE
Fix Run from Docker in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Run from Docker
 
 ```sh
-docker run --rm -it -v ~/.aws:/home/.aws tbrock/saw
+docker run --rm -it -v ~/.aws:$HOME/.aws tbrock/saw
 ```
 
 ## Installation


### PR DESCRIPTION
`saw` expects the `.aws` directory under `$HOME`, which is not explicitly defined by the docker image, thus the value `$HOME` from the current environment is being used (which is usually is not `/home`).