### PR TITLE
make `saw groups` reports errors

### DIFF
--- a/blade/blade.go
+++ b/blade/blade.go
@@ -57,10 +57,10 @@ func NewBlade(
 }
 
 // GetLogGroups gets the log groups from AWS given the blade configuration
-func (b *Blade) GetLogGroups() []*cloudwatchlogs.LogGroup {
+func (b *Blade) GetLogGroups() ([]*cloudwatchlogs.LogGroup, error) {
 	input := b.config.DescribeLogGroupsInput()
 	groups := make([]*cloudwatchlogs.LogGroup, 0)
-	b.cwl.DescribeLogGroupsPages(input, func(
+	err := b.cwl.DescribeLogGroupsPages(input, func(
 		out *cloudwatchlogs.DescribeLogGroupsOutput,
 		lastPage bool,
 	) bool {
@@ -69,7 +69,10 @@ func (b *Blade) GetLogGroups() []*cloudwatchlogs.LogGroup {
 		}
 		return !lastPage
 	})
-	return groups
+	if err != nil {
+		return nil, err
+	}
+	return groups, nil
 }
 
 // GetLogStreams gets the log streams from AWS given the blade configuration

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -17,7 +17,10 @@ var groupsCommand = &cobra.Command{
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
 		b := blade.NewBlade(&groupsConfig, &awsConfig, nil)
-		logGroups := b.GetLogGroups()
+		logGroups, err := b.GetLogGroups()
+		if err != nil {
+			fmt.Println("Error", err)
+		}
 		for _, group := range logGroups {
 			fmt.Println(*group.LogGroupName)
 		}


### PR DESCRIPTION
When unable to list groups (for example, the user doesn't have
permission), report errors instead of failing silently