### PR TITLE
Handle null event timestamp

### DIFF
--- a/config/configuration.go
+++ b/config/configuration.go
@@ -109,6 +109,14 @@ func (c *Configuration) TopStreamNames() []*string {
 	// FilerLogEvents can only take 100 streams so lets sort by LastEventTimestamp
 	// (descending) and take only the names of the most recent 100.
 	sort.Slice(c.Streams, func(i int, j int) bool {
+		if c.Streams[i].LastEventTimestamp == nil {
+			now := time.Now().UnixNano() / int64(time.Millisecond)
+			c.Streams[i].LastEventTimestamp = &now
+		}
+		if c.Streams[j].LastEventTimestamp == nil {
+			now := time.Now().UnixNano() / int64(time.Millisecond)
+			c.Streams[i].LastEventTimestamp = &now
+		}
 		return *c.Streams[i].LastEventTimestamp > *c.Streams[j].LastEventTimestamp
 	})
 


### PR DESCRIPTION
It's possible for the `LastEventTimestamp` to be `nil` and cause a panic.

I was seeing

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1f086af]

goroutine 1 [running]:
github.com/TylerBrock/saw/config.(*Configuration).TopStreamNames.func1(0x2, 0x1, 0xc00056f900)
	/Users/pete/projects.local/saw/config/configuration.go:112 +0x2f
sort.insertionSort_func(0xc00056fa28, 0xc0000ea060, 0x0, 0x7)
	/usr/local/Cellar/go/1.15.7_1/libexec/src/sort/zfuncversion.go:12 +0xb4
sort.quickSort_func(0xc00056fa28, 0xc0000ea060, 0x0, 0x7, 0x6)
	/usr/local/Cellar/go/1.15.7_1/libexec/src/sort/zfuncversion.go:158 +0x1f6
sort.Slice(0x2040600, 0xc0000ea040, 0xc00056fa28)
	/usr/local/Cellar/go/1.15.7_1/libexec/src/sort/slice.go:17 +0xf3
github.com/TylerBrock/saw/config.(*Configuration).TopStreamNames(0x32c3220, 0xc00040a550, 0xc000032a00, 0x0)
	/Users/pete/projects.local/saw/config/configuration.go:111 +0x8d
github.com/TylerBrock/saw/config.(*Configuration).FilterLogEventsInput(0x32c3220, 0xc000032a00)
	/Users/pete/projects.local/saw/config/configuration.go:81 +0x3ce
github.com/TylerBrock/saw/blade.(*Blade).GetEvents(0xc00044a500)
	/Users/pete/projects.local/saw/blade/blade.go:95 +0x65
github.com/apppackio/apppack/cmd.glob..func38(0x32b45c0, 0xc0003161a0, 0x0, 0x2)
	/Users/pete/projects.local/apppack-cli/cmd/logs.go:83 +0x325
github.com/spf13/cobra.(*Command).execute(0x32b45c0, 0xc000316180, 0x2, 0x2, 0x32b45c0, 0xc000316180)
	/Users/pete/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x32b5d60, 0xc00031a600, 0xffffffffffffffff, 0x32c38c0)
	/Users/pete/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/pete/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/apppackio/apppack/cmd.Execute()
	/Users/pete/projects.local/apppack-cli/cmd/root.go:67 +0x31
main.main()
	/Users/pete/projects.local/apppack-cli/main.go:38 +0x65
exit status 2
```