### PR TITLE
Update manual install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ sudo dpkg -i <the_deb_name>
 
 - [Install go](https://golang.org/doc/install)
 - Configure your `GOPATH` and add `$GOPATH/bin` to your path
-- Run `go get -u github.com/TylerBrock/saw`
+- Run `go install github.com/TylerBrock/saw@latest`
 
 #### Windows Specifics
 


### PR DESCRIPTION
Running `go get -u github.com/TylerBrock/saw` didn't add `saw` as a command for me, even after adding `%GOPATH%/bin` to my path. After running `go install github.com/TylerBrock/saw@latest` instead, it did. I believe this is the recommended way to install binaries now in Go.

https://stackoverflow.com/a/68559728
https://go.dev/blog/go116-module-changes#TOC_4.
https://go.dev/ref/mod#go-install