### PR TITLE
WiP - Add --noTimestamp arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - `--rawString` Print JSON strings instead of escaping ("\n", ...)
     - `--invert` Invert white colors to black for light color schemes
     - `--raw`, or `--pretty`, for `watch` and `get` commands respectively, toggles display of the timestamp and stream name prefix.
+    - `--noTimestamp` to supress only the timestamp, but not the stream name prefix
 
 - Filter logs using CloudWatch patterns
     - `--filter foo` Filter logs for the text "foo"

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -62,4 +62,5 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".`,
 	getCommand.Flags().BoolVar(&getOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	getCommand.Flags().BoolVar(&getOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")
 	getCommand.Flags().BoolVar(&getOutputConfig.RawString, "rawString", false, "print JSON strings without escaping")
+	getCommand.Flags().BoolVar(&watchOutputConfig.NoTimestamp, "noTimestamp", false, "print log without timestamp")
 }

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -47,4 +47,5 @@ func init() {
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Expand, "expand", false, "indent JSON log messages")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.Invert, "invert", false, "invert colors for light terminal themes")
 	watchCommand.Flags().BoolVar(&watchOutputConfig.RawString, "rawString", false, "print JSON strings without escaping")
+	watchCommand.Flags().BoolVar(&watchOutputConfig.NoTimestamp, "noTimestamp", false, "print log without timestamp")
 }

--- a/config/output.go
+++ b/config/output.go
@@ -12,6 +12,7 @@ type OutputConfiguration struct {
 	Invert    bool
 	RawString bool
 	NoColor   bool
+	NoTimestamp bool
 }
 
 func (c *OutputConfiguration) Formatter() *colorjson.Formatter {
@@ -31,6 +32,10 @@ func (c *OutputConfiguration) Formatter() *colorjson.Formatter {
 
 	if c.NoColor {
 		color.NoColor = true
+	}
+
+	if c.NoTimestamp {
+		formatter.NoTimestamp = true
 	}
 
 	return formatter


### PR DESCRIPTION
Trying to add an option to suppress only the timestamp, but keep the stream name as our logs all start with the DateTime info anyway, but I don't want to hide the stream name as need to see which logs from which node in a clusters the --raw is more than what I need

Can't see where https://github.com/TylerBrock/colorjson is adding the timestamp